### PR TITLE
add support for table and view materializations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## dbt-materialize
 
+[dbt](https://www.getdbt.com/) adapter for [Materialize](http://materialize.io). 
+
 Note, this plugin is a work in progress, and not yet suitable for production.
 
 ### Installation
@@ -10,4 +12,54 @@ $ pip install dbt-materialize
 
 ### Configuring your profile
 
-[Materialize](http://materialize.io) is based on the Postgres database protocols, so use the [dbt postgres settings](https://docs.getdbt.com/docs/profile-postgres) in your connection profile, only substitute `type: materialize` for `type: postgres`.
+[Materialize](http://materialize.io) is based on the Postgres database protocols, so use the
+[dbt postgres settings](https://docs.getdbt.com/docs/profile-postgres) in your connection profile,
+only substitute `type: materialize` for `type: postgres`.
+
+## Supported Features
+
+### Materializations
+
+Type | Supported? | Form in Materialize
+-----|------------|----------------
+table | :white_check_mark: | [materialized view](https://materialize.com/docs/sql/create-materialized-view/#main)
+view | :white_check_mark: | [view](https://materialize.com/docs/sql/create-view/#main)
+incremental | :x: |:x:
+ephemeral | :white_check_mark: | cte
+
+TL;DR: Use tables instead of incremental models when using Materialize as your data warehouse.
+
+Longer explanation:
+
+dbt's incremental models are valuable because they only spend your time and money transforming *new data*
+that has arrived in your data source. Luckily, this is exactly what Materialize's materialized views were
+built to do! Better yet, our materialized views will always return up-to-date results without manual or
+configured refreshed. For more information, check out [our documentation](https://materialize.com/docs/).
+
+### Seeds
+
+[`dbt seed`](https://docs.getdbt.com/reference/commands/seed/) will create a static materialized
+view from a csv file. You will not be able to add to or update this view after it has been created.
+
+### Hooks
+
+Not tested.
+
+### Custom Schemas
+
+Not tested.
+
+### Sources
+
+Not tested.
+
+### Testing and Documentation
+
+[`dbt docs` commands](https://docs.getdbt.com/reference/commands/cmd-docs) are supported.
+
+[`dbt test`](https://docs.getdbt.com/reference/commands/test) is untested.
+
+### Snapshots
+
+Not supported, will likely not be supported in the near term.  
+

--- a/dbt/include/materialize/macros/adapters.sql
+++ b/dbt/include/materialize/macros/adapters.sql
@@ -12,7 +12,7 @@
   );
 {%- endmacro %}
 
-{% macro postgres__create_schema(relation) -%}
+{% macro materialize__create_schema(relation) -%}
   {% if relation.database -%}
     {{ adapter.verify_database(relation.database) }}
   {%- endif -%}
@@ -21,7 +21,7 @@
   {%- endcall -%}
 {% endmacro %}
 
-{% macro postgres__drop_schema(relation) -%}
+{% macro materialize__drop_schema(relation) -%}
   {% if relation.database -%}
     {{ adapter.verify_database(relation.database) }}
   {%- endif -%}

--- a/dbt/include/materialize/macros/catalog.sql
+++ b/dbt/include/materialize/macros/catalog.sql
@@ -1,0 +1,52 @@
+{% macro materialize__get_catalog(information_schema, schemas) -%}
+
+  {%- call statement('catalog', fetch_result=True) -%}
+    {#
+      If the user has multiple databases set and the first one is wrong, this will fail.
+      But we won't fail in the case where there are multiple quoting-difference-only dbs, which is better.
+    #}
+    {% set database = information_schema.database %}
+    {{ adapter.verify_database(database) }}
+
+    select
+        '{{ database }}' as table_database,
+        sch.nspname as table_schema,
+        tbl.relname as table_name,
+        case tbl.relkind
+            when 'v' then 'VIEW'
+            else 'BASE TABLE'
+        end as table_type,
+        tbl_desc.description as table_comment,
+        col.attname as column_name,
+        col.attnum as column_index,
+        col.type as column_type,
+        col_desc.description as column_comment,
+        pg_get_userbyid(tbl.relowner) as table_owner
+
+    from pg_catalog.pg_namespace sch
+    join pg_catalog.pg_class tbl on tbl.relnamespace = sch.oid
+    join (select mz_columns.name as attname, position as attnum, mz_relations.oid as attrelid, FALSE as attisdropped, mz_columns.type as type
+          from mz_columns join mz_relations on mz_columns.id = mz_relations.id join mz_types on mz_columns.type = mz_types.name)
+          as col on col.attrelid = tbl.oid
+    left outer join pg_catalog.pg_description tbl_desc on (tbl_desc.objoid = tbl.oid and tbl_desc.objsubid = 0)
+    left outer join pg_catalog.pg_description col_desc on (col_desc.objoid = tbl.oid and col_desc.objsubid = col.attnum)
+
+    where (
+        {%- for schema in schemas -%}
+          upper(sch.nspname) = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}
+        {%- endfor -%}
+      )
+      and tbl.relkind in ('r', 'v', 'f', 'p') -- o[r]dinary table, [v]iew, [f]oreign table, [p]artitioned table. Other values are [i]ndex, [S]equence, [c]omposite type, [t]OAST table, [m]aterialized view
+      and col.attnum > 0 -- negative numbers are used for system columns such as oid
+      and not col.attisdropped -- column as not been dropped
+
+    order by
+        sch.nspname,
+        tbl.relname,
+        col.attnum
+
+  {%- endcall -%}
+
+  {{ return(load_result('catalog').table) }}
+
+{%- endmacro %}

--- a/dbt/include/materialize/macros/materializations/incremental.sql
+++ b/dbt/include/materialize/macros/materializations/incremental.sql
@@ -1,0 +1,14 @@
+{% materialization incremental, adapter='materialize' %}
+   -- Todo@jldlaughlin: Fail in a useful way!
+
+   -- TL;DR: dbt-materialize does not support incremental models, use table models
+   -- instead for the same functionality.
+
+   -- Longer explanation:
+   -- Incremental models are useful because instead of having to rebuild the entire table
+   -- in your data warehouse, dbt will only apply your transformations to new data.
+   -- Luckily, this is exactly what Materialize's materialized views do! As new data streams
+   -- in, Materialize only performs work on that new data. And, all this happens without
+   -- extra configurations or scheduled refreshes.
+   -- For more information, please visit: https://materialize.com/docs/
+{% endmaterialization %}

--- a/dbt/include/materialize/macros/materializations/seed.sql
+++ b/dbt/include/materialize/macros/materializations/seed.sql
@@ -43,9 +43,6 @@
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  -- `BEGIN` happens here:
-  {{ run_hooks(pre_hooks, inside_transaction=True) }}
-
   {% if old_relation %}
      {{ adapter.drop_relation(old_relation) }}
   {% endif %}
@@ -59,9 +56,6 @@
     {{ sql }}
   {% endcall %}
 
-  {{ run_hooks(post_hooks, inside_transaction=True) }}
-  -- `COMMIT` happens here
-  {{ adapter.commit() }}
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {% set target_relation = this.incorporate(type='table') %}

--- a/dbt/include/materialize/macros/materializations/table.sql
+++ b/dbt/include/materialize/macros/materializations/table.sql
@@ -1,0 +1,24 @@
+{% materialization table, adapter='materialize' %}
+  {%- set identifier = model['alias'] -%}
+  {%- set target_relation = api.Relation.create(identifier=identifier,
+                                                schema=schema,
+                                                database=database,
+                                                type='table') -%}
+
+  -- drop the relation if it exists for some reason
+  {{ adapter.drop_relation(target_relation) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- build model
+  {% call statement('main') -%}
+    {{ create_table_as(False, target_relation, sql) }}
+  {%- endcall %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+{% endmaterialization %}

--- a/dbt/include/materialize/macros/materializations/view.sql
+++ b/dbt/include/materialize/macros/materializations/view.sql
@@ -1,0 +1,24 @@
+{% materialization view, adapter='materialize' %}
+  {%- set identifier = model['alias'] -%}
+  {%- set target_relation = api.Relation.create(identifier=identifier,
+                                                schema=schema,
+                                                database=database,
+                                                type='view') -%}
+
+  -- drop the relation if it exists for some reason
+  {{ adapter.drop_relation(target_relation) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- build model
+  {% call statement('main') -%}
+    {{ create_view_as(target_relation, sql) }}
+  {%- endcall %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+{% endmaterialization %}

--- a/dbt/include/materialize/macros/relations.sql
+++ b/dbt/include/materialize/macros/relations.sql
@@ -25,3 +25,10 @@
   {% endcall %}
   {{ return(load_result('show_view').table) }}
 {% endmacro %}
+
+{% macro materialize_get_schemas() -%}
+  {% call statement('get_schemas', fetch_result=True, auto_begin=False) %}
+    show extended schemas
+  {% endcall %}
+  {{ return(load_result('get_schemas').table) }}
+{% endmacro %}

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 
 package_name = "dbt-materialize"
 package_version = "0.18.1"
-description = """The materialize adpter plugin for dbt (data build tool)"""
+description = """The Materialize adapter plugin for dbt (data build tool)"""
 
 setup(
     name=package_name,
@@ -20,7 +20,7 @@ setup(
 
     author='Josh Wills',
     author_email='joshwills+dbt@gmail.com',
-    url='https://github.com/jwills/dbt-materialize',
+    url='https://github.com/MaterializeInc/dbt-materialize',
     packages=find_packages(),
     package_data={
         'dbt': [

--- a/test/materialize.dbtspec
+++ b/test/materialize.dbtspec
@@ -11,11 +11,48 @@ sequences:
   test_dbt_empty: empty
   test_dbt_base: base
   test_dbt_schema_test: schema_test
-  # todo@jldlaughlin - unblock the following 3 tests
-  # test_dbt_data_test: data_test
-  # test_dbt_ephemeral: ephemeral -- blocked by CTEs in CREATE statements
-  # test_dbt_ephemeral_data_tests: data_test_ephemeral_models -- blocked by CTEs in CREATE statements
-  # no incrementals, no snapshots
+  test_dbt_ephemeral: ephemeral
+  test_dbt_ephemeral_data_tests: data_test_ephemeral_models
+  test_dbt_data_test: data_test
+  # dbt-materialize does not support incremental models or snapshots
   # test_dbt_incremental: incremental
   # test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
   # test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols
+
+
+# Custom base test that removes the last incremental portion.
+name: base
+project: base
+sequence:
+  - type: dbt
+    cmd: seed
+  - type: run_results
+    length: fact.seed.length
+  - type: dbt
+    cmd: run
+  - type: run_results
+    length: fact.run.length
+  - type: relation_types
+    expect: fact.expected_types_table
+  - type: relation_rows
+    name: base
+    length: fact.base.rowcount
+  - type: relations_equal
+    relations: fact.persisted_relations
+  - type: dbt
+    cmd: docs generate
+  - type: catalog
+    exists: True
+    nodes:
+      length: fact.catalog.nodes.length
+    sources:
+      length: fact.catalog.sources.length
+  # now swap
+  - type: dbt
+    cmd: run -m swappable
+    vars:
+      materialized_var: view
+  - type: run_results
+    length: 1
+  - type: relation_types
+    expect: fact.expected_types_view


### PR DESCRIPTION
Adds support for table and view model materialization. Table models will be created
as materialized views in Materialize, views will be created as views.

Adds a failing implementaiton for incremental models, which will not be supported
by dbt-materialize. Anyone looking to use an incremental model should be using our
table model instead (more information can be found in this project's README).