### PR TITLE
add "materializedview" materialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,18 @@ only substitute `type: materialize` for `type: postgres`.
 
 ### Materializations
 
-Type | Supported? | Form in Materialize
+Type | Supported? | Details
 -----|------------|----------------
-table | :white_check_mark: | [materialized view](https://materialize.com/docs/sql/create-materialized-view/#main)
-view | :white_check_mark: | [view](https://materialize.com/docs/sql/create-view/#main)
-incremental | :x: |:x:
-ephemeral | :white_check_mark: | cte
+view | :white_check_mark: | Creates a [view](https://materialize.com/docs/sql/create-view/#main).
+materializedview | :white_check_mark: | Creates a [materialized view](https://materialize.com/docs/sql/create-materialized-view/#main).
+table | :white_check_mark: | Creates a [materialized view](https://materialize.com/docs/sql/create-materialized-view/#main). (Actual table support pending [#5266](https://github.com/MaterializeInc/materialize/issues/5266))
+ephemeral | :white_check_mark: | Executes queries using CTEs.
+incremental | :x: | Use the `materializedview` materialization instead!
 
-TL;DR: Use tables instead of incremental models when using Materialize as your data warehouse.
-
-Longer explanation:
-
-dbt's incremental models are valuable because they only spend your time and money transforming *new data*
-that has arrived in your data source. Luckily, this is exactly what Materialize's materialized views were
-built to do! Better yet, our materialized views will always return up-to-date results without manual or
-configured refreshed. For more information, check out [our documentation](https://materialize.com/docs/).
+dbt's incremental models are valuable because they only spend your time and money transforming your new
+data as it arrives. Luckily, this is exactly what Materialize's materialized views were built to do! Better yet,
+our materialized views will always return up-to-date results without manual or configured refreshes.
+For more information, check out [our documentation](https://materialize.com/docs/).
 
 ### Seeds
 

--- a/dbt/include/materialize/macros/adapters.sql
+++ b/dbt/include/materialize/macros/adapters.sql
@@ -1,12 +1,12 @@
-{% macro materialize__create_table_as(temporary, relation, sql) -%}
-  create materialized view {{ relation }}
+{% macro materialize__create_view_as(relation, sql) -%}
+  create view {{ relation }}
   as (
     {{ sql }}
   );
 {%- endmacro %}
 
-{% macro materialize__create_view_as(relation, sql) -%}
-  create view {{ relation }}
+{% macro materialize__create_materialized_view_as(relation, sql) -%}
+  create materialized view {{ relation }}
   as (
     {{ sql }}
   );

--- a/dbt/include/materialize/macros/materializations/incremental.sql
+++ b/dbt/include/materialize/macros/materializations/incremental.sql
@@ -1,8 +1,8 @@
 {% materialization incremental, adapter='materialize' %}
    -- Todo@jldlaughlin: Fail in a useful way!
 
-   -- TL;DR: dbt-materialize does not support incremental models, use table models
-   -- instead for the same functionality.
+   -- TL;DR: dbt-materialize does not support incremental models, use materializedview
+   -- models instead.
 
    -- Longer explanation:
    -- Incremental models are useful because instead of having to rebuild the entire table

--- a/dbt/include/materialize/macros/materializations/materialized_view.sql
+++ b/dbt/include/materialize/macros/materializations/materialized_view.sql
@@ -1,4 +1,4 @@
-{% materialization table, adapter='materialize' %}
+{% materialization materializedview, adapter='materialize' %}
   {%- set identifier = model['alias'] -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
@@ -10,7 +10,6 @@
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   {% call statement('main') -%}
-    -- Creates a materialized view, not a table, in Materialize
     {{ create_materialized_view_as(target_relation, sql) }}
   {%- endcall %}
 

--- a/dbt/include/materialize/macros/materializations/seed.sql
+++ b/dbt/include/materialize/macros/materializations/seed.sql
@@ -58,6 +58,6 @@
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
-  {% set target_relation = this.incorporate(type='table') %}
+  {% set target_relation = this.incorporate(type='materializedview') %}
   {{ return({'relations': [target_relation]}) }}
 {% endmaterialization %}

--- a/dbt/include/materialize/macros/materializations/view.sql
+++ b/dbt/include/materialize/macros/materializations/view.sql
@@ -5,13 +5,10 @@
                                                 database=database,
                                                 type='view') -%}
 
-  -- drop the relation if it exists for some reason
   {{ adapter.drop_relation(target_relation) }}
 
-  -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  -- build model
   {% call statement('main') -%}
     {{ create_view_as(target_relation, sql) }}
   {%- endcall %}


### PR DESCRIPTION
We are currently hacking the `table` materialization to create a materialized view
under the hood. While this is still useful for testing purposes, it turns out that we can
just let users indicate `materializedview` as the materialization strategy for their
models, instead. This is a UX change that maps dbt + Materialize usage to what users
would be executing in Materialize directly.

This change was tested by the `materialize.dbtspec` tests, as well as by building
our [dbt-materialize-wikirecent](https://github.com/MaterializeInc/dbt-materialize-wikirecent) project with the changes.