### PR TITLE
install dbt-postgres in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         ]
     },
     install_requires=[
-        'dbt-core=={}'.format(package_version),
-        'psycopg2==2.8.4',
+        'dbt-postgres=={}'.format(package_version)
     ]
 )


### PR DESCRIPTION
Fixes #4. Explicitly require dbt-postgres instead of hand-selecting
adapter dependencies.