### PR TITLE
prefix create_materialized_view_as with materialize adapter name

### DIFF
--- a/dbt/include/materialize/macros/materializations/materialized_view.sql
+++ b/dbt/include/materialize/macros/materializations/materialized_view.sql
@@ -10,7 +10,7 @@
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   {% call statement('main') -%}
-    {{ create_materialized_view_as(target_relation, sql) }}
+    {{ materialize__create_materialized_view_as(target_relation, sql) }}
   {%- endcall %}
 
   {% do persist_docs(target_relation, model) %}

--- a/dbt/include/materialize/macros/materializations/table.sql
+++ b/dbt/include/materialize/macros/materializations/table.sql
@@ -11,7 +11,7 @@
 
   {% call statement('main') -%}
     -- Creates a materialized view, not a table, in Materialize
-    {{ create_materialized_view_as(target_relation, sql) }}
+    {{ materialize__create_materialized_view_as(target_relation, sql) }}
   {%- endcall %}
 
   {% do persist_docs(target_relation, model) %}


### PR DESCRIPTION
After destroying and recreating my local `venv`, dbt was unable to find the `create_materialized_view_as` macro without the prefix. I regrettably didn't `pip freeze` first, so I'm not sure why this was working for me before!