### PR TITLE
handle transactions opened with Materialize

### DIFF
--- a/dbt/adapters/materialize/connections.py
+++ b/dbt/adapters/materialize/connections.py
@@ -1,10 +1,10 @@
-from contextlib import contextmanager
-
 from dbt.adapters.postgres import PostgresConnectionManager
 from dbt.adapters.postgres import PostgresCredentials
-from dbt.adapters.sql import SQLConnectionManager
 
+import dbt.exceptions
 from dataclasses import dataclass
+from dbt import flags
+from dbt.logger import GLOBAL_LOGGER as logger
 
 @dataclass
 class MaterializeCredentials(PostgresCredentials):
@@ -15,3 +15,34 @@ class MaterializeCredentials(PostgresCredentials):
 class MaterializeConnectionManager(PostgresConnectionManager):
     TYPE = 'materialize'
 
+    @classmethod
+    def open(cls, connection):
+        connection = super().open(connection)
+        # Prevents psycopg connection from automatically opening transactions
+        # More info: https://www.psycopg.org/docs/usage.html#transactions-control
+        connection.handle.autocommit = True
+        return connection
+
+
+    def commit(self):
+        connection = self.get_thread_connection()
+        if flags.STRICT_MODE:
+            if not isinstance(connection, Connection):
+                raise dbt.exceptions.CompilerException(
+                    f'In commit, got {connection} - not a Connection!'
+                )
+
+        # Instead of throwing an error, quietly log if something tries to commit
+        # without an open transaction.
+        # This is needed because the dbt-adapter-tests commit after executing SQL,
+        # but Materialize can't handle all of the required transactions.
+        # https://github.com/fishtown-analytics/dbt/blob/42a85ac39f34b058678fd0c03ff8e8d2835d2808/test/integration/base.py#L681
+        if connection.transaction_open is False:
+            logger.debug('Tried to commit without a transaction on connection "{}"'.format(connection.name))
+
+        logger.debug('On {}: COMMIT'.format(connection.name))
+        self.add_commit_query()
+
+        connection.transaction_open = False
+
+        return connection

--- a/dbt/include/materialize/macros/adapters.sql
+++ b/dbt/include/materialize/macros/adapters.sql
@@ -16,7 +16,7 @@
   {% if relation.database -%}
     {{ adapter.verify_database(relation.database) }}
   {%- endif -%}
-  {%- call statement('create_schema') -%}
+  {%- call statement('create_schema', auto_begin=False) -%}
     create schema if not exists {{ relation.without_identifier().include(database=False) }}
   {%- endcall -%}
 {% endmacro %}
@@ -25,14 +25,14 @@
   {% if relation.database -%}
     {{ adapter.verify_database(relation.database) }}
   {%- endif -%}
-  {%- call statement('drop_schema') -%}
+  {%- call statement('drop_schema', auto_begin=False) -%}
     drop schema if exists {{ relation.without_identifier().include(database=False) }} cascade
   {%- endcall -%}
 {% endmacro %}
 
 {% macro materialize__rename_relation(from_relation, to_relation) -%}
   {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}
-  {% call statement('rename_relation') -%}
+  {% call statement('rename_relation', auto_begin=False) -%}
     alter view {{ from_relation }} rename to {{ target_name }}
   {%- endcall %}
 {% endmacro %}

--- a/dbt/include/materialize/macros/materializations/helpers.sql
+++ b/dbt/include/materialize/macros/materializations/helpers.sql
@@ -1,0 +1,10 @@
+{% macro run_hooks(hooks, inside_transaction=True) %}
+  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}
+    {% set rendered = render(hook.get('sql')) | trim %}
+    {% if (rendered | length) > 0 %}
+      {% call statement(auto_begin=inside_transaction) %}
+        {{ rendered }}
+      {% endcall %}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}

--- a/dbt/include/materialize/macros/materializations/materialized_view.sql
+++ b/dbt/include/materialize/macros/materializations/materialized_view.sql
@@ -9,7 +9,7 @@
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  {% call statement('main') -%}
+  {% call statement('main', auto_begin=False) -%}
     {{ materialize__create_materialized_view_as(target_relation, sql) }}
   {%- endcall %}
 

--- a/dbt/include/materialize/macros/materializations/seed.sql
+++ b/dbt/include/materialize/macros/materializations/seed.sql
@@ -28,7 +28,7 @@
     )
   {% endset %}
 
-  {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}
+  {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True, auto_begin=False) %}
   {{ return(sql) }}
 
 {%- endmacro %}

--- a/dbt/include/materialize/macros/materializations/table.sql
+++ b/dbt/include/materialize/macros/materializations/table.sql
@@ -9,7 +9,7 @@
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  {% call statement('main') -%}
+  {% call statement('main', auto_begin=False) -%}
     -- Creates a materialized view, not a table, in Materialize
     {{ materialize__create_materialized_view_as(target_relation, sql) }}
   {%- endcall %}

--- a/dbt/include/materialize/macros/materializations/view.sql
+++ b/dbt/include/materialize/macros/materializations/view.sql
@@ -9,7 +9,7 @@
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  {% call statement('main') -%}
+  {% call statement('main', auto_begin=False) -%}
     {{ create_view_as(target_relation, sql) }}
   {%- endcall %}
 

--- a/dbt/include/materialize/macros/relations.sql
+++ b/dbt/include/materialize/macros/relations.sql
@@ -1,33 +1,33 @@
 {% macro materialize_get_columns(relation) -%}
-  {% call statement('get_columns', fetch_result=True, auto_begin=False) %}
+  {% call statement('get_columns', fetch_result=True, auto_begin=True) %}
     show columns from {{ relation }}
   {% endcall %}
   {{ return(load_result('get_columns').table) }}
 {% endmacro %}
 
 {% macro materialize_get_full_views(schema) -%}
-  {% call statement('get_full_views', fetch_result=True, auto_begin=False) %}
+  {% call statement('get_full_views', fetch_result=True, auto_begin=True) %}
     show full views from {{ schema }}
   {% endcall %}
   {{ return(load_result('get_full_views').table) }}
 {% endmacro %}
 
 {% macro materialize_get_sources(schema) -%}
-  {% call statement('get_sources', fetch_result=True, auto_begin=False) %}
+  {% call statement('get_sources', fetch_result=True, auto_begin=True) %}
     show sources from {{ schema }}
   {% endcall %}
   {{ return(load_result('get_sources').table) }}
 {% endmacro %}
 
 {% macro materialize_show_view(relation) -%}
-  {% call statement('show_view', fetch_result=True, auto_begin=False) %}
+  {% call statement('show_view', fetch_result=True, auto_begin=True) %}
     show create view {{ relation }}
   {% endcall %}
   {{ return(load_result('show_view').table) }}
 {% endmacro %}
 
 {% macro materialize_get_schemas() -%}
-  {% call statement('get_schemas', fetch_result=True, auto_begin=False) %}
+  {% call statement('get_schemas', fetch_result=True, auto_begin=True) %}
     show extended schemas
   {% endcall %}
   {{ return(load_result('get_schemas').table) }}


### PR DESCRIPTION
Materialize is just starting to handle transactions. In its current
state, SELECT and SHOW statements can be executed in a transaction,
but any other statements that perform updates (ex: DROP, CREATE),
cannot.

This change explicitly allows SELECT and SHOW statements to open a
transaction, but blocks all other statements from doing so.